### PR TITLE
타입스크립트를 포함한 컴파일 시 build file이 생성되는 프로젝트를 위한 ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Type build
+build


### PR DESCRIPTION
타입스크립트를 포함한 컴파일 시 build file이 생성되는 프로젝트를 위한 gitignore설정이 필요합니다